### PR TITLE
Advanced Is<T>: An overload which returns the query result as an out parameter

### DIFF
--- a/src/CoreLibrary/Assets/Scripts/CoreLibrary/Base/ComponentQueryExtensions.cs
+++ b/src/CoreLibrary/Assets/Scripts/CoreLibrary/Base/ComponentQueryExtensions.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace CoreLibrary
 {
     /// <summary>
-    /// Author: Cameron Reuschel
+    /// Authors: Cameron Reuschel, Daniel Götz
     /// <br/><br/>
     /// Holds a number of extension methods to find a game object's
     /// components of a certain type in a concise and flexible manner.
@@ -98,14 +98,46 @@ namespace CoreLibrary
         {
             return tr.gameObject.Find<T>(fn, where);
         }
+        
+        /// <example>
+        /// Before C# 7
+        /// <code>
+        /// Collider result;
+        /// if(gameObject.Is&lt;Collider&gt;(out result))
+        ///     result.trigger = true;
+        /// </code>
+        /// After C# 7
+        /// <code>
+        /// if(gameObject.Is&lt;Collider&gt;(out var result))
+        ///     result.trigger = true;
+        /// </code>
+        /// </example>
+        /// <param name="result">If the component T has been found, it will be assigned to this variable</param>
+        /// <param name="where">Optional search scope if the object itself does not have the component.</param>
+        /// <typeparam name="T">The type of the component to find.</typeparam>
+        /// <returns>true if any object in the specified search scope has a component of type T.</returns>
+        public static bool Is<T>(this GameObject go, out T result, Search where = Search.InObjectOnly) where T : class{
+            result = go.As<T>(where);
+            return !Util.IsNull(result);
+        }
+
+        /// <inheritdoc cref="Is{T}(UnityEngine.GameObject,out T,CoreLibrary.Search)" />
+        public static bool Is<T>(this Component comp, out T result, Search where = Search.InObjectOnly) where T : class{
+            return comp.gameObject.Is<T>(out result, where);
+        }
+
+        /// <inheritdoc cref="Is{T}(UnityEngine.GameObject,out T,CoreLibrary.Search)" />
+        public static bool Is<T>(this Collision col, out T result, Search where = Search.InObjectOnly) where T : class {
+            return col.gameObject.Is<T>(out result, where);
+        }
 
         /// <param name="where">Optional search scope if the object itself does not have the component.</param>
         /// <typeparam name="T">The type of the component to find.</typeparam>
         /// <returns>true if any object in the specified search scope has a component of type T.</returns>
         public static bool Is<T>(this GameObject go, Search where = Search.InObjectOnly) where T : class
         {
-            var res = go.As<T>(where);
-            return !Util.IsNull(res);
+            T unused;
+            return go.Is<T>(out unused, where);
         }
 
         /// <inheritdoc cref="Is{T}(GameObject, Search)"/>


### PR DESCRIPTION
I implemented an overload for Is, which enables the following:
Instead of writing
````
if(this.Is<Collider>(Search.InChildren)){
 var collider = this.As<Collider>(Search.InChildren);
 collider.trigger = true;
}
````
there is an overload for all the ``Is`` methods, that is used like the following (only possible starting c#7 and upwards - it is a little less useful before)
````
if(this.Is<Collider>(out var result, Search.InChildren)){
  result.trigger = true;
}
````
Saves a line and an unneccesarry query, without really sacrificing readability.
It kinda works like 
``if(foo is MyClass asMyClass)``

To be done by XDracam:
Add documentation of a use case to the markdown docu, and compile it.
You can use the example given in the xml docu of my Is<T> method